### PR TITLE
Add mnist training using Tensorflow on EKS

### DIFF
--- a/tensorflow/mnist/Dockerfile
+++ b/tensorflow/mnist/Dockerfile
@@ -1,0 +1,5 @@
+FROM tensorflow/tensorflow 
+RUN apt-get update && apt-get install -y git
+RUN git clone https://github.com/fchollet/keras.git /root/keras/
+RUN git clone -b 1.1.0 https://github.com/apache/incubator-mxnet.git /root/incubator-mxnet
+RUN pip install keras

--- a/tensorflow/mnist/tensorflow.yaml
+++ b/tensorflow/mnist/tensorflow.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tensorflow 
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: tensorflow 
+    image: rgaut/deeplearning-tensorflow:with_tf_keras
+    command:
+      - "python"
+      - "/root/keras/examples/mnist_cnn.py" 
+       


### PR DESCRIPTION
88e9fe562973:k8s-machine-learning gauta$ kubectl get pods tensorflow
NAME         READY     STATUS    RESTARTS   AGE
tensorflow   1/1       Running   0          5m
88e9fe562973:k8s-machine-learning gauta$ 

Training has started 

88e9fe562973:k8s-machine-learning gauta$ kubectl logs tensorflow
Using TensorFlow backend.
Downloading data from https://s3.amazonaws.com/img-datasets/mnist.npz

   16384/11490434 [..............................] - ETA: 0s
   24576/11490434 [..............................] - ETA: 36s
   57344/11490434 [..............................] - ETA: 31s
  122880/11490434 [..............................] - ETA: 21s
  303104/11490434 [..............................] - ETA: 11s
  557056/11490434 [>.............................] - ETA: 7s 
 1155072/11490434 [==>...........................] - ETA: 4s
 2334720/11490434 [=====>........................] - ETA: 2s
 3907584/11490434 [=========>....................] - ETA: 1s
 5480448/11490434 [=============>................] - ETA: 0s
 7053312/11490434 [=================>............] - ETA: 0s
 8626176/11490434 [=====================>........] - ETA: 0s
10199040/11490434 [=========================>....] - ETA: 0s
11493376/11490434 [==============================] - 1s 0us/step

11501568/11490434 [==============================] - 1s 0us/step
2018-09-19 08:12:43.142740: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
x_train shape: (60000, 28, 28, 1)
60000 train samples
10000 test samples
Train on 60000 samples, validate on 10000 samples
Epoch 1/12

  128/60000 [..............................] - ETA: 4:56 - loss: 2.3072 - acc: 0.1094
  256/60000 [..............................] - ETA: 3:30 - loss: 2.2785 - acc: 0.1367
  384/60000 [..............................] - ETA: 3:00 - loss: 2.2411 - acc: 0.1901
  512/60000 [..............................] - ETA: 2:45 - loss: 2.2161 - acc: 0.2070
  640/60000 [..............................] - ETA: 2:37 - loss: 2.1876 - acc: 0.2422
  768/60000 [..............................] - ETA: 2:30 - loss: 2.1491 - acc: 0.2617
  896/60000 [..............................] - ETA: 2:25 - loss: 2.1092 - acc: 0.2846
 1024/60000 [..............................] - ETA: 2:22 - loss: 2.0544 - acc: 0.3096
 1152/60000 [..............................] - ETA: 2:20 - loss: 1.9965 - acc: 0.3316
 1280/60000 [..............................] - ETA: 2:17 - loss: 1.9899 - a