### PR TITLE
Adding jupyter notebook example for tensorflow

### DIFF
--- a/notebook/tensorflow/tensorflow.md
+++ b/notebook/tensorflow/tensorflow.md
@@ -1,0 +1,36 @@
+# Jupyter Notebook for TensorFlow on Amazon EKS
+
+This document explains how to run Jupyter notebook for TensorFlow [Amazon EKS](https://aws.amazon.com/eks/). 
+
+The good news official tensorflow docker has jupyter notebook install into it and it starts when tensorflow docker runs. The only thing needed was to do a port forwarding and using k8s logs login to jupyter notebook.
+
+1. You can create a pod by using `k8s-machine-learning/notebook/tensorflow/tensorflow.yaml`. It uses official tensorflow docker image. 
+
+   ```
+   kubectl create -f tensorflow.yaml 
+   ```
+
+   This will create a tensorflow pod. 
+
+2. By default when this pod runs, it has jupyter notebook running, but we need to do port-forwarding in order to access the jupyter notebook. You can use below command to map the jupyter notebook port to one of your host port
+
+
+   ```
+   kubectl port-forward tensorflow 8888:8888
+   ```
+
+   In general port-forwarding format is 
+
+   ```
+   kubectl port-forward <pod_name>  <host_port>:<pod_port at which your app is running>
+   ```
+
+
+3. Login to the Jupyter notebook. You can navigate to `127.0.0.1:8888` to access the jupyter notebook. However it will ask for the `token`. Since tensorflow container starts the jupyter notebook, if we can look at the logs we can get the token from there. 
+
+   ```
+   kubectl logs tensorflow 
+   ```
+
+   Above command will print the log of jupyter notebook start up which will include the token.
+

--- a/notebook/tensorflow/tensorflow.yaml
+++ b/notebook/tensorflow/tensorflow.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tensorflow 
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: tensorflow 
+    image: tensorflow/tensorflow 
+       


### PR DESCRIPTION
Step 1: Creating the pod
kubectl create -f tensorflow.yaml 
tensorflow   1/1       Running   0          36m

Step 2: Port Forwarding
 kubectl port-forward tensorflow 8888:8888 
error: unable to forward port because pod is not running. Current status=Pending
88e9fe562973:my_pods gauta$ kubectl port-forward tensorflow 8888:8888 
Forwarding from 127.0.0.1:8888 -> 8888
Forwarding from [::1]:8888 -> 8888
Handling connection for 8888


Step 3: login using token
kubectl logs tensorflow 
[I 07:21:07.077 NotebookApp] Writing notebook server cookie secret to /root/.local/share/jupyter/runtime/notebook_cookie_secret
[W 07:21:07.092 NotebookApp] WARNING: The notebook server is listening on all IP addresses and not using encryption. This is not recommended.
[I 07:21:07.099 NotebookApp] Serving notebooks from local directory: /notebooks
[I 07:21:07.100 NotebookApp] The Jupyter Notebook is running at:
[I 07:21:07.100 NotebookApp] http://(tensorflow or 127.0.0.1):8888/?token=336e983652d97481cf90807e9bbfd3d1b69a7940db49c971
[I 07:21:07.100 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[C 07:21:07.100 NotebookApp] 
    
    Copy/paste this URL into your browser when you connect for the first time,
    to login with a token:
        http://(tensorflow or 127.0.0.1):8888/?token=336e983652d97481cf90807e9bbfd3d1b69a7940db49c971
