### PR TITLE
Adding AWS Deep Learning Container references

### DIFF
--- a/mxnet.md
+++ b/mxnet.md
@@ -8,10 +8,10 @@ This documents assumes that you have an EKS cluster available and running. Make 
 
 In this sample, we'll use MNIST database of handwritten digits and train the model to recognize any handwritten digit.
 
-1. You can use a pre-built Docker image `rgaut/deeplearning-mxnet:with_mxnet`. Alternatively, duild a docker image with MNIST source code and installation. Use the Dockerfile in `mxnet/mnist/Dockerfile` to use it.
+1. You can use a pre-built Docker image `rgaut/deeplearning-mxnet:with_mxnet`. Alternatively, build a docker image with MNIST source code and installation. Use the Dockerfile in `samples/mxnet/mnist/Dockerfile` to build it. This Dockerfile is based on [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/). You will need to login to access the repository of [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/) by running the command `$(aws ecr get-login --no-include-email --region us-east-1 --registry-ids 763104351884)`.   
 
    ```
-   docker image build mxnet/mnist -t <tag_for_image>
+   docker build -t <tag_for_image> .
    ```
 
    This will generate a docker image which will have all the utility to run MNIST. You can push this generated image to docker hub in your personal repo.

--- a/samples/mxnet/mnist/Dockerfile
+++ b/samples/mxnet/mnist/Dockerfile
@@ -1,3 +1,3 @@
-FROM mxnet/python:gpu 
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/mxnet-training:1.4.0-gpu-py27-cu90-ubuntu16.04 
 RUN apt-get update && apt-get install -y git
 RUN git clone -b 1.1.0 https://github.com/apache/incubator-mxnet.git /root/incubator-mxnet

--- a/samples/tensorflow/mnist/Dockerfile
+++ b/samples/tensorflow/mnist/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow 
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:1.13-horovod-gpu-py27-cu100-ubuntu16.04 
 RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/fchollet/keras.git /root/keras/
 RUN git clone -b 1.1.0 https://github.com/apache/incubator-mxnet.git /root/incubator-mxnet

--- a/tensorboard.md
+++ b/tensorboard.md
@@ -42,3 +42,14 @@ This document explains how to setup TensorBoard on [Amazon EKS](https://aws.amaz
    kubectl port-forward svc/${TENSORBOARD_COMPONENT} 9000:9000
    ```
    ![TensorBoard](images/tensorboard.png)
+
+4. [OPTIONAL] You can use [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/) by replacing the lines 
+   ```
+   ks param set ${TENSORBOARD_COMPONENT} defaultTbImage tensorflow/tensorflow:1.12.0
+   ```
+   to 
+   ```
+   ks param set ${TENSORBOARD_COMPONENT} defaultTbImage 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:1.13-cpu-py27-ubuntu16.04 
+   ```
+   You will need to login to access the repository of [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/) by running the command `$(aws ecr get-login --no-include-email --region us-east-1 --registry-ids 763104351884)`
+   A full list of images can be found [here](https://docs.aws.amazon.com/dlami/latest/devguide/deep-learning-containers-images.html).

--- a/tensorflow-horovod-synthetic.md
+++ b/tensorflow-horovod-synthetic.md
@@ -48,7 +48,7 @@ This document explains how to perform distributed training on [Amazon EKS](https
    ks generate mpi-job-custom ${JOB_NAME}
    ```
 
-2. Build a Docker image for Horovod using Dockerfile from `training/distributed_training/Dockerfile` and the command `docker image build -t ${YOUR_DOCKER_HUB_ID}/eks-kubeflow-horovod:latest .`. Alternatively, you can use the image `mpioperator/tensorflow-benchmarks:latest` that already exists on Docker Hub.
+2. You can leverage [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/) to Build a Docker image for Horovod using Dockerfile from `training/distributed_training/Dockerfile`. You will need to login to access the repository of [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/) by running the command `$(aws ecr get-login --no-include-email --region us-east-1 --registry-ids 763104351884)` and then build command `docker image build -t ${YOUR_DOCKER_HUB_ID}/eks-kubeflow-horovod:latest .`. Alternatively, you can use the image `mpioperator/tensorflow-benchmarks:latest` that already exists on Docker Hub.
 
    ```
    ks param set ${JOB_NAME} image "mpioperator/tensorflow-benchmarks:latest"

--- a/tensorflow-inference-kubeflow.md
+++ b/tensorflow-inference-kubeflow.md
@@ -68,12 +68,21 @@ This document explains how to perform Tensorflow inference on [Amazon EKS](https
 ### Upload pretrained model to S3
 
 1. Download Tensorflow model and export saved model
-   If you has GPU nodes, use
+   If you has GPU nodes, use [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/)
+   ```
+   nvidia-docker run -it -v /tmp/saved_model:/model 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference:1.13-gpu-py27-cu100-ubuntu16.04 bash 
+   ``` 
+   Alternatively 
    ```
    nvidia-docker run -it -v /tmp/saved_model:/model tensorflow/tensorflow:1.12.0-gpu bash
    ```
-   If you use CPU for serving, use
 
+   If you use CPU for serving, use [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/)
+
+   ```
+   docker run -it -v /tmp/saved_model:/model 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference:1.13-cpu-py27-ubuntu16.04 bash 
+   ```
+   Alternatively 
    ```
    docker run -it -v /tmp/saved_model:/model tensorflow/tensorflow:1.12.0 bash
    ```
@@ -97,5 +106,7 @@ This document explains how to perform Tensorflow inference on [Amazon EKS](https
        |-- variables.data-00000-of-00001
        `-- variables.index
    ```
+
+   Note thatn you will need to login to access the repository of [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/) by running the command `$(aws ecr get-login --no-include-email --region us-east-1 --registry-ids 763104351884)`  
 
 2. Create S3 bucket and upload your models to `s3://eks-tensorflow-model/mnist/1`. `1` is model version number. You can also use our pretrained model [here](samples/tensorflow-serving/model). This requires your serving component has GPU.

--- a/tensorflow-keras.md
+++ b/tensorflow-keras.md
@@ -8,10 +8,10 @@ This document exaplins how to run a TensorFlow and Keras sample on Amazon EKS. I
 
 In this sample, we'll use MNIST database of handwritten digits and train the model to recognize any handwritten digit.
 
-1. You can use a pre-built Docker image `rgaut/deeplearning-tensorflow:with_tf_keras`. Alternatively, build a docker image with MNIST source code and installation. Use the Dockerfile in `tensorflow/mnist/Dockerfile` to use it.
-
+1. You can use a pre-built Docker image `rgaut/deeplearning-tensorflow:with_tf_keras`. Alternatively, build a docker image with MNIST source code and installation. Use the Dockerfile in `samples/tensorflow/mnist/Dockerfile` to build it. This Dockerfile is based on [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/). You will need to login to access the repository of [AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/) by running the command `$(aws ecr get-login --no-include-email --region us-east-1 --registry-ids 763104351884)`.
+ 
    ```
-   docker image build tensorflow/mnist -t <dockerhub_username>/<repo_name>:<tag_name>
+   docker build -t <dockerhub_username>/<repo_name>:<tag_name> .
    ```
 
    This will generate a docker image which will have all the utility to run MNIST. You can push this generated image to docker hub in your personal repo.

--- a/training/distributed_training/Dockerfile
+++ b/training/distributed_training/Dockerfile
@@ -1,4 +1,4 @@
-FROM uber/horovod:0.15.2-tf1.12.0-torch1.0.0-py2.7
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:1.13-horovod-gpu-py27-cu100-ubuntu16.04
 
 RUN mkdir /tensorflow
 WORKDIR "/tensorflow"


### PR DESCRIPTION
Adding the AWS Deep Learning Containers references to all the required Dockerfile as well as in instructions. 