### PR TITLE
Add the export_dir for mnist model

### DIFF
--- a/samples/mnist/training/tensorflow/Dockerfile
+++ b/samples/mnist/training/tensorflow/Dockerfile
@@ -1,5 +1,6 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:1.13-horovod-gpu-py27-cu100-ubuntu16.04 
+FROM tensorflow/tensorflow
 RUN apt-get update && apt-get install -y git
-RUN git clone https://github.com/fchollet/keras.git /root/keras/
-RUN git clone -b 1.1.0 https://github.com/apache/incubator-mxnet.git /root/incubator-mxnet
-RUN pip install keras
+RUN git clone -b r1.12.0 https://github.com/tensorflow/models.git /tmp/models
+ENV PYTHONPATH="$PYTHONPATH:/tmp/models"
+RUN pip install --user -r /tmp/models/official/requirements.txt
+

--- a/samples/mnist/training/tensorflow/tensorflow.yaml
+++ b/samples/mnist/training/tensorflow/tensorflow.yaml
@@ -6,8 +6,8 @@ spec:
   restartPolicy: OnFailure
   containers:
   - name: tensorflow 
-    image: rgaut/deeplearning-tensorflow:with_tf_keras
+    image: rgaut/deeplearning-tensorflow:with_model 
     command:
       - "python"
-      - "/root/keras/examples/mnist_cnn.py" 
+      - "/tmp/models/official/mnist/mnist.py --export_dir /model/"
        


### PR DESCRIPTION
A tensorflow image with mnist code.
This mnist.py accepts an argumnet --export_dir to export the train model.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
