### PR TITLE
Adding the hostpath for export model

### DIFF
--- a/samples/mnist/training/tensorflow/tensorflow.yaml
+++ b/samples/mnist/training/tensorflow/tensorflow.yaml
@@ -12,4 +12,14 @@ spec:
     image: rgaut/deeplearning-tensorflow:with_model 
     command:
       - "python"
-      - "/tmp/models/official/mnist/mnist.py --export_dir /model/"
+      - "/tmp/models/official/mnist/mnist.py"
+      - "--export_dir"
+      - "/model"
+    volumeMounts:
+    - mountPath: /model
+      name: test-volume
+  volumes:
+  - name: test-volume
+    hostPath:
+      # directory location on host
+      path: /tmp


### PR DESCRIPTION
Due to host path setup pod will leave the model into one of the worker node of your EKS cluster.
In this case it will be in some directory under /tmp/<some random number>
 one e.g

 [ec2-user@ip-x.x.x.x8 1554868983]$ pwd
 /tmp/1554868983
 [ec2-user@ip-y.y.y.y 1554868983]$ ls -al
 total 40
 drwxr-xr-x 3 root root    45 Apr 10 04:03 .
 drwxrwxrwt 9 root root   190 Apr 10 04:03 ..
 -rw-r--r-- 1 root root 37706 Apr 10 04:03 saved_model.pb
 drwxr-xr-x 2 root root    66 Apr 10 04:03 variables

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
